### PR TITLE
[feat] 增加进度条，更换输入组件，增加暂停

### DIFF
--- a/release/build_multi.bat
+++ b/release/build_multi.bat
@@ -22,7 +22,7 @@ pyinstaller --onefile --windowed --icon=logo.ico --name "%EXE_NAME%" ../main_mul
 :: Modify the .spec file to include additional files and hiddenimports
 powershell -Command "(Get-Content %EXE_NAME%.spec) -replace 'datas=\[', 'datas=[(''../src'', ''src''), (''../utils'', ''utils'')' | Set-Content %EXE_NAME%.spec"
 :: powershell -Command "(Get-Content %EXE_NAME%.spec) -replace 'hiddenimports=\[', 'hiddenimports=[''os'',''tkinter'',''tkinter.filedialog'',''tkinter.messagebox'',''re'',''dataclasses'',''pyautogui'',''time'',''threading'',''argparse'',''pretty_midi'',''sys'',''ctypes'',''typing'',''packaging''' | Set-Content %EXE_NAME%.spec"
-powershell -Command "(Get-Content %EXE_NAME%.spec) -replace 'hiddenimports=\[', 'hiddenimports=[''os'',''tkinter'',''tkinter.filedialog'',''tkinter.messagebox'',''re'',''dataclasses'',''pynput.keyboard'',''time'',''threading'',''argparse'',''pretty_midi'',''sys'',''ctypes'',''typing'',''packaging''' | Set-Content %EXE_NAME%.spec"
+powershell -Command "(Get-Content %EXE_NAME%.spec) -replace 'hiddenimports=\[', 'hiddenimports=[''os'',''tkinter'',''tkinter.filedialog'',''tkinter.messagebox'',''re'',''dataclasses'',''pynput.keyboard'',''pynput'',''time'',''threading'',''argparse'',''pretty_midi'',''sys'',''ctypes'',''typing'',''packaging''' | Set-Content %EXE_NAME%.spec"
 
 :: Build again using the modified .spec file
 pyinstaller "%EXE_NAME%.spec" --distpath "dist_multi" --upx-dir=upx-5.0.0-win64

--- a/release/build_single.bat
+++ b/release/build_single.bat
@@ -22,7 +22,7 @@ pyinstaller --onefile --windowed --icon=logo.ico --name "%EXE_NAME%" ../main_sin
 :: Modify the .spec file to include additional files and hiddenimports
 powershell -Command "(Get-Content %EXE_NAME%.spec) -replace 'datas=\[', 'datas=[(''../src'', ''src''), (''../utils'', ''utils'')' | Set-Content %EXE_NAME%.spec"
 :: powershell -Command "(Get-Content %EXE_NAME%.spec) -replace 'hiddenimports=\[', 'hiddenimports=[''os'',''tkinter'',''tkinter.filedialog'',''tkinter.messagebox'',''re'',''dataclasses'',''pyautogui'',''time'',''threading'',''argparse'',''pretty_midi'',''sys'',''ctypes'',''typing'',''packaging''' | Set-Content %EXE_NAME%.spec"
-powershell -Command "(Get-Content %EXE_NAME%.spec) -replace 'hiddenimports=\[', 'hiddenimports=[''os'',''tkinter'',''tkinter.filedialog'',''tkinter.messagebox'',''re'',''dataclasses'',''pynput.keyboard'',''time'',''threading'',''argparse'',''pretty_midi'',''sys'',''ctypes'',''typing'',''packaging''' | Set-Content %EXE_NAME%.spec"
+powershell -Command "(Get-Content %EXE_NAME%.spec) -replace 'hiddenimports=\[', 'hiddenimports=[''os'',''tkinter'',''tkinter.filedialog'',''tkinter.messagebox'',''re'',''dataclasses'',''pynput.keyboard'',''pynput'',''time'',''threading'',''argparse'',''pretty_midi'',''sys'',''ctypes'',''typing'',''packaging''' | Set-Content %EXE_NAME%.spec"
 
 :: Build again using the modified .spec file
 pyinstaller "%EXE_NAME%.spec" --distpath "dist_single" --upx-dir=upx-5.0.0-win64

--- a/src/app.py
+++ b/src/app.py
@@ -1,6 +1,6 @@
 import os
 import tkinter as tk
-from tkinter import filedialog, messagebox
+from tkinter import filedialog, messagebox, ttk
 from typing import List, Optional
 
 from src.player import Player
@@ -44,6 +44,13 @@ class BaseApp:
         self.ent_latency = tk.Entry(params, width=8)
         self.ent_latency.insert(0, "0")
         self.ent_latency.grid(row=0, column=5, sticky="w", padx=6)
+        
+        # 添加进度更新频率配置
+        tk.Label(params, text="进度更新频率：").grid(row=1, column=0, sticky="e")
+        self.ent_progress_freq = tk.Entry(params, width=8)
+        self.ent_progress_freq.insert(0, "1")
+        self.ent_progress_freq.grid(row=1, column=1, sticky="w", padx=6)
+        tk.Label(params, text="(1=每个动作都更新, 2=每2个动作更新, 以此类推)").grid(row=1, column=2, columnspan=4, sticky="w")
 
     def _create_control_frame(self):
         ctrl = tk.Frame(self.frm)
@@ -54,6 +61,14 @@ class BaseApp:
         self.btn_stop.pack(side="left", padx=4)
         self.lbl_status = tk.Label(ctrl, text="状态：等待载入乐谱")
         self.lbl_status.pack(side="left", padx=10)
+        
+        # 添加进度条框架
+        progress_frame = tk.Frame(self.frm)
+        progress_frame.pack(fill="x", pady=4)
+        self.lbl_progress = tk.Label(progress_frame, text="进度：0%")
+        self.lbl_progress.pack(side="left", padx=10)
+        self.progress_bar = ttk.Progressbar(progress_frame, mode='determinate', length=300)
+        self.progress_bar.pack(side="left", padx=4, fill="x", expand=True)
 
     def _create_tips_frame(self):
         tips = tk.LabelFrame(self.frm, text="使用提示")
@@ -64,6 +79,21 @@ class BaseApp:
             "3) 载入后切换到游戏窗口，回到本工具点击开始；\n"
             "4) 如无响应尝试以管理员身份运行 Python。"
         )).pack(fill="x")
+
+    def update_progress(self, current: int, total: int):
+        """更新进度条和进度标签"""
+        if total > 0:
+            percentage = int((current / total) * 100)
+            self.progress_bar['value'] = percentage
+            self.lbl_progress.config(text=f"进度：{percentage}% ({current}/{total})")
+        else:
+            self.progress_bar['value'] = 0
+            self.lbl_progress.config(text="进度：0%")
+
+    def reset_progress(self):
+        """重置进度条"""
+        self.progress_bar['value'] = 0
+        self.lbl_progress.config(text="进度：0%")
 
     def load_score(self):
         """加载乐谱文件，支持 .lrcp 或 .mid；若为 .mid 则先自动转换为 .lrcp 再读取"""
@@ -119,6 +149,7 @@ class BaseApp:
         if self.player:
             self.player.stop()
             self.player = None
+            self.reset_progress()
 
 
 if __name__ == '__main__':

--- a/src/app.py
+++ b/src/app.py
@@ -55,7 +55,7 @@ class BaseApp:
     def _create_control_frame(self):
         ctrl = tk.Frame(self.frm)
         ctrl.pack(fill="x", pady=6)
-        self.btn_start = tk.Button(ctrl, text="开始演奏", command=self.start_play, state="disabled")
+        self.btn_start = tk.Button(ctrl, text="开始演奏", command=self.toggle_play_pause, state="disabled")
         self.btn_start.pack(side="left", padx=4)
         self.btn_stop = tk.Button(ctrl, text="停止", command=self.stop_play, state="disabled")
         self.btn_stop.pack(side="left", padx=4)
@@ -150,6 +150,34 @@ class BaseApp:
             self.player.stop()
             self.player = None
             self.reset_progress()
+            # 恢复按钮与状态
+            self.btn_start.config(state="normal", text="开始演奏")
+            self.btn_stop.config(state="disabled")
+            self.lbl_status.config(text="完成/已停止")
+
+    def toggle_play_pause(self):
+        """开始/暂停/继续 切换。若未开始则调用子类的 start_play。"""
+        if not self.player:
+            # 未开始：启动
+            self.start_play()
+            return
+        # 已有 player：切换暂停/继续
+        try:
+            if hasattr(self.player, 'is_paused') and self.player.is_paused():
+                self.player.resume()
+                self.btn_start.config(text="暂停")
+                self.lbl_status.config(text="演奏中…")
+            else:
+                # 进入暂停
+                if hasattr(self.player, 'pause'):
+                    self.player.pause()
+                    self.btn_start.config(text="继续")
+                    self.lbl_status.config(text="已暂停")
+        except Exception:
+            try:
+                self.stop_play()
+            except Exception:
+                pass
 
 
 if __name__ == '__main__':

--- a/src/app_multi.py
+++ b/src/app_multi.py
@@ -70,7 +70,8 @@ class MultiApp(BaseApp):
 
         # 每次开始前按当前偏移重新生成
         self.update_play_events()
-        self.btn_start.config(state="disabled")
+        # 开始后：启用停止按钮；开始按钮显示为“暂停”并保持可点击
+        self.btn_start.config(state="normal", text="暂停")
         self.btn_stop.config(state="normal")
         self.lbl_status.config(text=f'演奏中… (总 {len(self.play_events)} 单音事件)')
         
@@ -78,9 +79,10 @@ class MultiApp(BaseApp):
         self.reset_progress()
 
         def on_done():
-            self.btn_start.config(state="normal")
+            self.btn_start.config(state="normal", text="开始演奏")
             self.btn_stop.config(state="disabled")
             self.lbl_status.config(text='完成/已停止')
+            self.player = None
 
         self.player = Player(self.play_events, countin, latency, speed, on_done, self.update_progress, progress_freq)
         self.player.start()

--- a/src/app_multi.py
+++ b/src/app_multi.py
@@ -29,10 +29,13 @@ class MultiApp(BaseApp):
         # 添加多人模式特有的参数 - 使用正确的行数
         params = self.frm.winfo_children()[1]  # 获取第二个子元素（params）
         tk.Label(params, text="多音偏移(ms):").grid(row=2, column=0, sticky="e")
-        self.ent_offsets = tk.Entry(params, width=20)
+        self.ent_offsets = tk.Entry(params, width=11)
         self.ent_offsets.insert(0, "-15,0,15")
         self.ent_offsets.grid(row=2, column=1, columnspan=3, sticky="w", padx=4)
-        tk.Label(params, text="范围-50~50，按顺序循环应用到同一时间的多个音").grid(row=2, column=4, columnspan=2, sticky="w")
+        tk.Label(params, text="范围-50~50，按顺序循环应用到同一时间的多个音").grid(row=2, column=2, columnspan=2, sticky="w")
+        # 把偏移输入框加入可统一控制的参数控件
+        if hasattr(self, 'param_widgets'):
+            self.param_widgets.append(self.ent_offsets)
 
     def _parse_score(self, score_text: str) -> List[Event]:
         return parse_score(score_text, multi=True)
@@ -77,12 +80,16 @@ class MultiApp(BaseApp):
         
         # 重置进度条
         self.reset_progress()
+        # 禁用参数，避免误输入
+        self.disable_params()
 
         def on_done():
             self.btn_start.config(state="normal", text="开始演奏")
             self.btn_stop.config(state="disabled")
             self.lbl_status.config(text='完成/已停止')
             self.player = None
+            # 恢复参数
+            self.enable_params()
 
         self.player = Player(self.play_events, countin, latency, speed, on_done, self.update_progress, progress_freq)
         self.player.start()

--- a/src/app_multi.py
+++ b/src/app_multi.py
@@ -26,13 +26,13 @@ class MultiApp(BaseApp):
             '4) 适度调整偏移可减少漏音（建议 -20~20 范围内微调）。'
         )).pack(fill="x")
 
-        # 添加多人模式特有的参数
+        # 添加多人模式特有的参数 - 使用正确的行数
         params = self.frm.winfo_children()[1]  # 获取第二个子元素（params）
-        tk.Label(params, text="多音偏移(ms):").grid(row=1, column=0, sticky="e")
+        tk.Label(params, text="多音偏移(ms):").grid(row=2, column=0, sticky="e")
         self.ent_offsets = tk.Entry(params, width=20)
         self.ent_offsets.insert(0, "-15,0,15")
-        self.ent_offsets.grid(row=1, column=1, columnspan=3, sticky="w", padx=4)
-        tk.Label(params, text="范围-50~50，按顺序循环应用到同一时间的多个音").grid(row=1, column=4, columnspan=2, sticky="w")
+        self.ent_offsets.grid(row=2, column=1, columnspan=3, sticky="w", padx=4)
+        tk.Label(params, text="范围-50~50，按顺序循环应用到同一时间的多个音").grid(row=2, column=4, columnspan=2, sticky="w")
 
     def _parse_score(self, score_text: str) -> List[Event]:
         return parse_score(score_text, multi=True)
@@ -62,19 +62,27 @@ class MultiApp(BaseApp):
             latency = int(float(self.ent_latency.get()))
         except:
             latency = 0
+            
+        try:
+            progress_freq = int(float(self.ent_progress_freq.get()))
+        except:
+            progress_freq = 1
 
         # 每次开始前按当前偏移重新生成
         self.update_play_events()
         self.btn_start.config(state="disabled")
         self.btn_stop.config(state="normal")
         self.lbl_status.config(text=f'演奏中… (总 {len(self.play_events)} 单音事件)')
+        
+        # 重置进度条
+        self.reset_progress()
 
         def on_done():
             self.btn_start.config(state="normal")
             self.btn_stop.config(state="disabled")
             self.lbl_status.config(text='完成/已停止')
 
-        self.player = Player(self.play_events, countin, latency, speed, on_done)
+        self.player = Player(self.play_events, countin, latency, speed, on_done, self.update_progress, progress_freq)
         self.player.start()
 
     def parse_offsets(self) -> List[int]:

--- a/src/app_single.py
+++ b/src/app_single.py
@@ -64,6 +64,8 @@ class SingleApp(BaseApp):
         self.btn_start.config(state="normal", text="暂停")
         self.btn_stop.config(state="normal")
         self.lbl_status.config(text="演奏中…（切到游戏保持焦点）")
+        # 禁用参数，避免误输入
+        self.disable_params()
         
         # 重置进度条
         self.reset_progress()
@@ -73,6 +75,8 @@ class SingleApp(BaseApp):
             self.btn_stop.config(state="disabled")
             self.lbl_status.config(text="完成/已停止")
             self.player = None
+            # 恢复参数
+            self.enable_params()
 
         self.player = Player(self.events, countin, latency, speed, on_done, self.update_progress, progress_freq)
         self.player.start()

--- a/src/app_single.py
+++ b/src/app_single.py
@@ -55,17 +55,25 @@ class SingleApp(BaseApp):
             latency = int(float(self.ent_latency.get()))
         except:
             latency = 0
+            
+        try:
+            progress_freq = int(float(self.ent_progress_freq.get()))
+        except:
+            progress_freq = 1
 
         self.btn_start.config(state="disabled")
         self.btn_stop.config(state="normal")
         self.lbl_status.config(text="演奏中…（切到游戏保持焦点）")
+        
+        # 重置进度条
+        self.reset_progress()
 
         def on_done():
             self.btn_start.config(state="normal")
             self.btn_stop.config(state="disabled")
             self.lbl_status.config(text="完成/已停止")
 
-        self.player = Player(self.events, countin, latency, speed, on_done)
+        self.player = Player(self.events, countin, latency, speed, on_done, self.update_progress, progress_freq)
         self.player.start()
 
 

--- a/src/app_single.py
+++ b/src/app_single.py
@@ -61,7 +61,7 @@ class SingleApp(BaseApp):
         except:
             progress_freq = 1
 
-        self.btn_start.config(state="disabled")
+        self.btn_start.config(state="normal", text="暂停")
         self.btn_stop.config(state="normal")
         self.lbl_status.config(text="演奏中…（切到游戏保持焦点）")
         
@@ -69,9 +69,10 @@ class SingleApp(BaseApp):
         self.reset_progress()
 
         def on_done():
-            self.btn_start.config(state="normal")
+            self.btn_start.config(state="normal", text="开始演奏")
             self.btn_stop.config(state="disabled")
             self.lbl_status.config(text="完成/已停止")
+            self.player = None
 
         self.player = Player(self.events, countin, latency, speed, on_done, self.update_progress, progress_freq)
         self.player.start()

--- a/src/player.py
+++ b/src/player.py
@@ -1,13 +1,13 @@
 import time
 import threading
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Optional, Callable
 
 from src.event import Event, SimpleEvent
 from src.key_sender import key_sender
 
 
 class Player(threading.Thread):
-    def __init__(self, events: List[Union[Event, SimpleEvent]], start_delay: float, global_latency_ms: int, speed_ratio: float, on_done):
+    def __init__(self, events: List[Union[Event, SimpleEvent]], start_delay: float, global_latency_ms: int, speed_ratio: float, on_done, progress_callback: Optional[Callable[[int, int], None]] = None, progress_update_freq: int = 1):
         super().__init__(daemon=True)
         self.events = events
         self.start_delay = max(0.0, start_delay)
@@ -15,11 +15,14 @@ class Player(threading.Thread):
         self.speed_ratio = max(0.05, speed_ratio)
         self._stop = threading.Event()
         self.on_done = on_done
+        self.progress_callback = progress_callback
+        self.progress_update_freq = max(1, progress_update_freq)  # 确保至少为1
 
     def stop(self):
         self._stop.set()
 
     def run(self):
+        total_actions = 0
         try:
             if not self.events:
                 return
@@ -48,7 +51,9 @@ class Player(threading.Thread):
             actions.sort(key=lambda x: x[0])
             t0 = time.perf_counter() + self.start_delay
             idx = 0
-            while idx < len(actions) and not self._stop.is_set():
+            total_actions = len(actions)
+
+            while idx < total_actions and not self._stop.is_set():
                 now = time.perf_counter()
                 target = t0 + actions[idx][0] + self.global_latency
                 wait = target - now
@@ -61,9 +66,17 @@ class Player(threading.Thread):
                 else:
                     key_sender.release(keys)
                 idx += 1
+                
+                # 根据用户配置的频率更新进度
+                if self.progress_callback and (idx % self.progress_update_freq == 0 or idx == total_actions):
+                    self.progress_callback(idx, total_actions)
+                    
         finally:
             # 确保释放所有剩余按键
             key_sender.release_all()
+            # 报告完成进度
+            if self.progress_callback:
+                self.progress_callback(total_actions, total_actions)
             if self.on_done:
                 self.on_done()
 


### PR DESCRIPTION
1. 单人与多人ui上增加静态的演奏进度条
2. 当开始演奏后，可以选择暂停，然后可以接着继续演奏；演奏进度条也同步
3. 输入框替换为不可编辑的下拉/微调控件
4. 在开始演奏时禁用参数控件、停止后恢复，以避免按键被输入
5. 打包脚本里的增加标准库pynput

<img width="936" height="482" alt="image" src="https://github.com/user-attachments/assets/875a5833-f38e-4803-bc9b-a6984f590beb" />
